### PR TITLE
Makefile: fix up commands, add new targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,15 @@
+CC= 	gcc
+LIB= 	-Wall -lncurses
+PREFIX= /usr/local
 
-LIB= -lncurses
-CC = gcc
+chad_stride: 	chad_stride.c
+	$(CC) -o $@ $^ $(LIB)
 
-chad_stride: chad_stride.c
-	$(CC) $(LIB) $^ -o chad_stride
+install: 	chad_stride
+	install -m 755 -D chad_stride $(PREFIX)/bin/chad_stride
+
+uninstall:
+	rm -f $(PREFIX)/bin/chad_stride
+
+clean:
+	rm -f chad_stride


### PR DESCRIPTION
- install will build and install chad_stride to $(PREFIX)/bin

- uninstall will remove chad_stride from $(PREFIX)/bin

- clean will remove built binary

- Add -Wall to CFLAGS

Examples:

    $ make PREFIX=/tmp install

    $ /tmp/bin/chad_stride

    $ make PREFIX=/tmp uinstall

    $ make clean

TODO: need to cleanup warning about row being unused