### PR TITLE
Add chad_stride to Snap

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ make uninstall
 
 **Snap:**
 ```
-snap install chad-stride
+snap install --edge chad-stride
 ```
 
 ### Windows

--- a/README.md
+++ b/README.md
@@ -72,6 +72,11 @@ make uninstall
 
 `yay -S chad_stride`
 
+**Snap:**
+```
+snap install chad-stride
+```
+
 ### Windows
 
 Someone please tell me

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,18 @@
+name: chad-stride 
+version: 0.695
+summary: A small curses program to stride across your terminal
+description: chad_stride is a program similar to sl (steam locomotive). It will display Chad in all his glory striding across your terminal. Use chad_stride -h for custimization.
+parts:
+    chad-stride:
+        plugin: make
+        source-type: tar    
+        source:  https://github.com/sambattalio/chad_stride/archive/0.6951.tar.gz       
+        build-packages:
+            - gcc
+            - make
+            - libncurses5-dev
+            - libncursesw5-dev
+apps:
+    chad-stride:
+        command: chad_stride
+


### PR DESCRIPTION
Added snapcraft.yaml to build a snap of chad_stride and included instructions for installation in the README.

Currently, chad_stride is uploaded to https://snapcraft.io/chad-stride . At the moment, in order to update this snap, I would have to manually update the snapcraft.yaml, build locally, and upload to the snap store. 

However, by including the yaml file in this repo, we can set chad_stride to be automatically uploaded to the snap store on every change:

https://snapcraft.io/blog/we-are-changing-the-way-you-build-snaps-from-github-repos

With this, we can simply choose "Build with Github" on this snap and give Snap access to create a webhook on this repo. Since I'm not an owner of the repo, I can make you a collaborator of the snap, which will allow you to link the snap with this repo for automatic snap builds.